### PR TITLE
Filtering would only work 1st go

### DIFF
--- a/winners/2021-hall-of-fame.json
+++ b/winners/2021-hall-of-fame.json
@@ -447,7 +447,7 @@
   },
   {
     "name": "Abby Bangser",
-    "date": "14/04/2021",
+    "date": "14/05/2021",
     "note": "Nominated by Thomas Rinke: for her interactive and insightful #99MinuteWorkshop on #TestingInProduction. It was fun and led to a better understanding of some concepts around that topic.",
     "twitter": "https://twitter.com/a_bangser",
     "linkedin": "https://www.linkedin.com/in/abbybangser"
@@ -557,7 +557,7 @@
   },
   {
     "name": "Gáspár Nagy",
-    "date": "29/03/2021",
+    "date": "29/04/2021",
     "note": "Nominated by Thomas Rinke: for his perspectives shared in the @ministryoftest Banglaore online meetup 'Deliberate discovery of requirements with BDD'",
     "twitter": "https://twitter.com/gasparnagy",
     "linkedin": "https://www.linkedin.com/in/gasparnagy",


### PR DESCRIPTION
I've not fixed the actual problem, however there were 2 duplicate dates in the 2021 json winners, which Vue was using as a key. When the dates were fixed (they seemed out of whack given their place chronologically anyway) it appears the user can filter multiple times again.